### PR TITLE
fix: prevent home horizontal overflow

### DIFF
--- a/FlightApp/Views/Search/FlightSearchView.swift
+++ b/FlightApp/Views/Search/FlightSearchView.swift
@@ -46,12 +46,14 @@ struct FlightSearchView: View {
                         // Recent flights section
                         if !recentSearchStore.recentSearches.isEmpty {
                             recentFlightsSection
+                                .padding(.horizontal, 20)
                                 .padding(.bottom, 32)
                         }
 
                         // Recent routes section
                         if !recentRouteStore.recentRoutes.isEmpty {
                             recentRoutesSection
+                                .padding(.horizontal, 20)
                                 .padding(.bottom, 32)
                         }
 
@@ -59,7 +61,7 @@ struct FlightSearchView: View {
                         discoverSection
                             .padding(.bottom, 100) // Space for bottom search bar
                     }
-                    .padding(.horizontal, 20)
+                    .frame(maxWidth: .infinity)
                 }
 
                 // Unified search bar (liquid glass)
@@ -299,7 +301,6 @@ struct FlightSearchView: View {
                 .padding(.horizontal, 20)
             }
         }
-        .padding(.horizontal, -20) // Counteract parent padding
     }
 
     // MARK: - Helper Functions


### PR DESCRIPTION
## Summary
Linear: https://linear.app/kushsagentworkspace/issue/WORK-5/fix-flighttracky-home-horizontal-scroll-overflow

- Remove the negative horizontal padding used to make the Discover carousel full-bleed
- Apply horizontal padding only to the vertical sections that need it
- Keep the root vertical scroll content constrained to the screen width to avoid accidental horizontal bounce/drag

## Test Plan
- ✅ `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme FlightApp -project FlightApp.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' build CODE_SIGNING_ALLOWED=NO`
- ✅ `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme FlightApp -project FlightApp.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' CODE_SIGNING_ALLOWED=NO`

Note: local verification required a temporary ignored `FlightApp/Config.xcconfig` with the template API key placeholder because the real config is not committed.
