### PR TITLE
fix: prevent modal horizontal overflow

### DIFF
--- a/FlightApp/Views/Flight/FlightView.swift
+++ b/FlightApp/Views/Flight/FlightView.swift
@@ -37,76 +37,80 @@ struct FlightView: View {
                 .background(.ultraThinMaterial)
                 .ignoresSafeArea()
 
-            ScrollView {
-                VStack(spacing: 0) {
-                    if let flight = viewModel.currentFlight {
-                    // Hero section with flight number and route
-                    FlightHeroSection(flight: flight)
-                        .padding(.horizontal)
-                        .padding(.top)
+            GeometryReader { geometry in
+                ScrollView(.vertical) {
+                    VStack(spacing: 0) {
+                        if let flight = viewModel.currentFlight {
+                            // Hero section with flight number and route
+                            FlightHeroSection(flight: flight)
+                                .padding(.horizontal)
+                                .padding(.top)
 
-                    // Route map - full width, no padding
-                    FlightRouteMapView(flight: flight)
-                        .padding(.top, 20)
+                            // Route map - full width, no padding
+                            FlightRouteMapView(flight: flight)
+                                .padding(.top, 20)
 
-                        VStack(spacing: 20) {
-                            // Time and progress information
-                            let flightTimes = viewModel.getFlightTimes()
-                            FlightRouteCard(
-                                flight: flight,
-                                times: flightTimes
-                            )
+                            VStack(spacing: 20) {
+                                // Time and progress information
+                                let flightTimes = viewModel.getFlightTimes()
+                                FlightRouteCard(
+                                    flight: flight,
+                                    times: flightTimes
+                                )
 
-                            // Gate and terminal information
-                            FlightGateTerminalCard(flight: flight)
+                                // Gate and terminal information
+                                FlightGateTerminalCard(flight: flight)
 
-                            // Aircraft and route details
-                            FlightAircraftCard(flight: flight)
+                                // Aircraft and route details
+                                FlightAircraftCard(flight: flight)
 
-                            // Aircraft insights
-                            if let aircraftType = flight.aircraftType {
+                                // Aircraft insights
+                                if let aircraftType = flight.aircraftType {
+                                    InsightCard(
+                                        type: .aircraft,
+                                        context: InsightContext(
+                                            flightNumber: flight.ident,
+                                            airline: flight.operatorName,
+                                            aircraftType: aircraftType
+                                        ),
+                                        airlineColors: AirlineColorService.shared.getBrandColors(for: flight.operatorIata)
+                                    )
+                                }
+
+                                // Destination insights
                                 InsightCard(
-                                    type: .aircraft,
+                                    type: .destination,
                                     context: InsightContext(
-                                        flightNumber: flight.ident,
-                                        airline: flight.operatorName,
-                                        aircraftType: aircraftType
+                                        destinationAirport: flight.destination.code,
+                                        destinationCity: flight.destination.city
                                     ),
                                     airlineColors: AirlineColorService.shared.getBrandColors(for: flight.operatorIata)
                                 )
+
+                                // Airline profile section
+                                airlineProfileSection
                             }
-
-                            // Destination insights
-                            InsightCard(
-                                type: .destination,
-                                context: InsightContext(
-                                    destinationAirport: flight.destination.code,
-                                    destinationCity: flight.destination.city
-                                ),
-                                airlineColors: AirlineColorService.shared.getBrandColors(for: flight.operatorIata)
-                            )
-
-                            // Airline profile section
-                            airlineProfileSection
-                        }
-                        .padding()
-                    } else if viewModel.isLoading {
-                        LoadingView(flightNumber: flightNumber)
                             .padding()
-                    } else if let error = viewModel.error {
-                        FlightErrorView(
-                            flightNumber: flightNumber,
-                            errorMessage: error.localizedDescription,
-                            onRetry: {
-                                viewModel.searchFlight(flightNumber: flightNumber)
-                            },
-                            onBack: {
-                                dismiss()
-                            }
-                        )
-                        .padding()
+                        } else if viewModel.isLoading {
+                            LoadingView(flightNumber: flightNumber)
+                                .padding()
+                        } else if let error = viewModel.error {
+                            FlightErrorView(
+                                flightNumber: flightNumber,
+                                errorMessage: error.localizedDescription,
+                                onRetry: {
+                                    viewModel.searchFlight(flightNumber: flightNumber)
+                                },
+                                onBack: {
+                                    dismiss()
+                                }
+                            )
+                            .padding()
+                        }
                     }
+                    .frame(width: geometry.size.width)
                 }
+                .clipped()
             }
         }
         .navigationTitle("Flight Details")

--- a/FlightApp/Views/Route/RouteView.swift
+++ b/FlightApp/Views/Route/RouteView.swift
@@ -25,17 +25,20 @@ struct RouteView: View {
                     .background(.ultraThinMaterial)
                     .ignoresSafeArea()
 
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: 0) {
-                        if viewModel.isLoading {
-                            loadingView
-                        } else if let error = viewModel.error {
-                            errorView(error)
-                        } else {
-                            routeContentView
+                GeometryReader { geometry in
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(spacing: 0) {
+                            if viewModel.isLoading {
+                                loadingView
+                            } else if let error = viewModel.error {
+                                errorView(error)
+                            } else {
+                                routeContentView
+                            }
                         }
+                        .frame(width: geometry.size.width)
                     }
-                    .frame(maxWidth: .infinity)
+                    .clipped()
                 }
             }
             .navigationTitle("\(origin) → \(destination)")


### PR DESCRIPTION
## Summary
- Fix modal horizontal overflow on flight detail and route views by constraining vertical scroll content to the sheet viewport width
- Explicitly keep both modal scroll views vertical-only and clip any over-wide child content instead of allowing horizontal drag/bounce
- Covers expanded insight/dropdown content such as Aircraft Info, Destination Info, and Route/Award insight cards

## Test Plan
- ✅ `git diff --check`
- ✅ `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -scheme FlightApp -project FlightApp.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' build CODE_SIGNING_ALLOWED=NO`
- ✅ `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -scheme FlightApp -project FlightApp.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' CODE_SIGNING_ALLOWED=NO`

Note: local build/test used a temporary ignored `FlightApp/Config.xcconfig` copied from `Config-Template.xcconfig`, then removed it after verification.